### PR TITLE
Coordinates

### DIFF
--- a/src/components/Canvas/DraggingComponent.js
+++ b/src/components/Canvas/DraggingComponent.js
@@ -185,7 +185,6 @@ class DraggingComponent extends PureComponent {
   onDoubleClick(e) {}
 
   onMouseDown(e) {
-    //console.log("mousedown", e);
     this.startDragPhase(e);
   }
 

--- a/src/components/Canvas/DraggingComponent.js
+++ b/src/components/Canvas/DraggingComponent.js
@@ -7,6 +7,7 @@
  */
 
 import React, { PureComponent } from "react";
+import PropTypes from "prop-types";
 
 import { omit } from "lodash-es";
 
@@ -38,10 +39,10 @@ class DraggingComponent extends PureComponent {
    * If no movement is happening, inInDragPhase is undefined
    */
 
-  static defaultProps = {
-    engine: "canvas",
-    showModBar: true,
-  };
+  // static defaultProps = {
+  //   engine: "canvas",
+  //   showModBar: true,
+  // };
 
   state = {
     mouse: {
@@ -393,5 +394,32 @@ class DraggingComponent extends PureComponent {
     );
   }
 }
+
+DraggingComponent.defaultProps = {
+  overflow: "auto",
+  overflowX: "initial",
+  overflowY: "initial",
+  scrollBarPositionX: "bottom",
+  scrollBarPositionY: "right",
+  scrollBarWidth: 5,
+  showModBar: true,
+  engine: "canvas",
+  sequenceDisableDragging: false,
+};
+
+DraggingComponent.propTypes = {
+  overflow: PropTypes.oneOf(["hidden", "auto", "scroll"]),
+  overflowX: PropTypes.oneOf(["hidden", "auto", "scroll", "initial"]),
+  overflowY: PropTypes.oneOf(["hidden", "auto", "scroll", "initial"]),
+  width: PropTypes.number.isRequired,
+  height: PropTypes.number.isRequired,
+  fullHeight: PropTypes.number.isRequired,
+  fullWidth: PropTypes.number.isRequired,
+  scrollBarPositionX: PropTypes.oneOf(["top", "bottom"]),
+  scrollBarPositionY: PropTypes.oneOf(["left", "right"]),
+  showModBar: PropTypes.bool,
+  engine: PropTypes.string,
+  sequenceDisableDragging: PropTypes.bool,
+};
 
 export default DraggingComponent;

--- a/src/components/Canvas/DraggingComponent.js
+++ b/src/components/Canvas/DraggingComponent.js
@@ -334,6 +334,7 @@ class DraggingComponent extends PureComponent {
       ...this.props.style,
       cursor: this.state.mouse.cursorState,
       position: "relative",
+      flexShrink: 0,
     };
     const modBar = {
       position: "absolute",

--- a/src/components/Canvas/SequenceViewer.js
+++ b/src/components/Canvas/SequenceViewer.js
@@ -515,6 +515,12 @@ SequenceViewerComponent.propTypes = {
    * Y Position of the scroll bar ("left" or "right")
    */
   scrollBarPositionY: PropTypes.oneOf(["left", "right"]),
+
+  /**
+   * The conservation data can be used to define an overlay that
+   * defines the opacity of the background color of each residue.
+   */
+  overlayConservation: PropTypes.bool,
 };
 
 // hoist the list of accepted properties to the parent
@@ -541,7 +547,9 @@ const mapStateToProps = (state) => {
     tileHeight: state.props.tileHeight,
     colorScheme: state.props.colorScheme,
     overlayConservation: state.props.overlayConservation,
-    conservation: state.props.overlayConservation ? state.props.conservation : null,
+    conservation: state.props.overlayConservation
+      ? state.props.conservation
+      : null,
     nrXTiles: state.sequenceStats.nrXTiles,
     nrYTiles: state.sequenceStats.nrYTiles,
     fullWidth: state.sequenceStats.fullWidth,

--- a/src/components/Canvas/SequenceViewer.js
+++ b/src/components/Canvas/SequenceViewer.js
@@ -408,6 +408,7 @@ SequenceViewerComponent.defaultProps = {
   scrollBarPositionY: "right",
   overlayConservation: false,
   conservation: null,
+  sequenceDisableDragging: false,
 };
 
 SequenceViewerComponent.propTypes = {
@@ -521,6 +522,8 @@ SequenceViewerComponent.propTypes = {
    * defines the opacity of the background color of each residue.
    */
   overlayConservation: PropTypes.bool,
+  onPositionUpdate: PropTypes.func,
+  sequenceDisableDragging: PropTypes.bool,
 };
 
 // hoist the list of accepted properties to the parent

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -7,8 +7,16 @@
  */
 
 import Labels from "./yBars/Labels";
+import Coordinates from "./yBars/Coordinates";
 import PositionBar from "./xBars/PositionBar";
 import OverviewBar from "./xBars/OverviewBar";
 import SequenceViewer from "./Canvas/SequenceViewer";
 import SequenceOverview from "./Canvas/SequenceOverview";
-export { Labels, OverviewBar, PositionBar, SequenceOverview, SequenceViewer };
+export {
+  Labels,
+  Coordinates,
+  OverviewBar,
+  PositionBar,
+  SequenceOverview,
+  SequenceViewer,
+};

--- a/src/components/layouts/MSALayouter.js
+++ b/src/components/layouts/MSALayouter.js
@@ -66,6 +66,7 @@ class MSALayouter extends PureComponent {
       sequenceScrollBarPositionY: "scrollBarPositionY",
       sequenceDisableDragging: same,
       overlayConservation: same,
+      onPositionUpdate: same,
     },
     // List of props forwarded to the left Coordinates component
     leftCoordinatesProps: {

--- a/src/components/layouts/MSALayouter.js
+++ b/src/components/layouts/MSALayouter.js
@@ -66,6 +66,18 @@ class MSALayouter extends PureComponent {
       sequenceScrollBarPositionY: "scrollBarPositionY",
       sequenceDisableDragging: same,
     },
+    // List of props forwarded to the left Coordinates component
+    leftCoordinatesProps: {
+      leftCoordinateComponent: "coordinateComponent",
+      leftCoordinateStyle: "coordinateStyle",
+      leftCoordinateAttributes: "coordinateAttributes",
+    },
+    // List of props forwarded to the right Coordinates component
+    rightCoordinatesProps: {
+      rightCoordinateComponent: "coordinateComponent",
+      rightCoordinateStyle: "coordinateStyle",
+      rightCoordinateAttributes: "coordinateAttributes",
+    },
     // List of props forwarded to the Labels component
     labelsProps: {
       labelComponent: same,

--- a/src/components/layouts/MSALayouter.js
+++ b/src/components/layouts/MSALayouter.js
@@ -65,15 +65,18 @@ class MSALayouter extends PureComponent {
       sequenceScrollBarPositionX: "scrollBarPositionX",
       sequenceScrollBarPositionY: "scrollBarPositionY",
       sequenceDisableDragging: same,
+      overlayConservation: same,
     },
     // List of props forwarded to the left Coordinates component
     leftCoordinatesProps: {
+      leftCoordinate: same,
       leftCoordinateComponent: "coordinateComponent",
       leftCoordinateStyle: "coordinateStyle",
       leftCoordinateAttributes: "coordinateAttributes",
     },
     // List of props forwarded to the right Coordinates component
     rightCoordinatesProps: {
+      rightCoordinate: same,
       rightCoordinateComponent: "coordinateComponent",
       rightCoordinateStyle: "coordinateStyle",
       rightCoordinateAttributes: "coordinateAttributes",

--- a/src/components/layouts/basic.js
+++ b/src/components/layouts/basic.js
@@ -8,13 +8,7 @@
 
 import React from "react";
 
-import {
-  Labels,
-  OverviewBar,
-  PositionBar,
-  SequenceViewer,
-  Coordinates,
-} from "../index";
+import { Labels, OverviewBar, PositionBar, SequenceViewer } from "../index";
 
 import PureBaseLayout from "./PureBaseLayout";
 import msaConnect from "../../store/connect";
@@ -32,11 +26,9 @@ class MSABasicLayout extends PureBaseLayout {
     const separatorPadding = {
       height: 10,
     };
-    console.log(this.props);
     return (
       <div style={labelsAndSequenceDiv}>
         <Labels style={labelsStyle} {...this.props.labelsProps} />
-        <Coordinates style={labelsStyle} />
         <div>
           <OverviewBar
             height={overviewBarHeight}
@@ -46,7 +38,6 @@ class MSABasicLayout extends PureBaseLayout {
           <SequenceViewer {...this.props.sequenceViewerProps} />
           <div style={separatorPadding} />
         </div>
-        <Coordinates style={labelsStyle} />
       </div>
     );
     //<SequenceOverview />

--- a/src/components/layouts/basic.js
+++ b/src/components/layouts/basic.js
@@ -8,7 +8,13 @@
 
 import React from "react";
 
-import { Labels, OverviewBar, PositionBar, SequenceViewer } from "../index";
+import {
+  Labels,
+  OverviewBar,
+  PositionBar,
+  SequenceViewer,
+  Coordinates,
+} from "../index";
 
 import PureBaseLayout from "./PureBaseLayout";
 import msaConnect from "../../store/connect";
@@ -26,9 +32,11 @@ class MSABasicLayout extends PureBaseLayout {
     const separatorPadding = {
       height: 10,
     };
+    console.log(this.props);
     return (
       <div style={labelsAndSequenceDiv}>
         <Labels style={labelsStyle} {...this.props.labelsProps} />
+        <Coordinates style={labelsStyle} />
         <div>
           <OverviewBar
             height={overviewBarHeight}
@@ -38,6 +46,7 @@ class MSABasicLayout extends PureBaseLayout {
           <SequenceViewer {...this.props.sequenceViewerProps} />
           <div style={separatorPadding} />
         </div>
+        <Coordinates style={labelsStyle} />
       </div>
     );
     //<SequenceOverview />

--- a/src/components/layouts/nightingale.js
+++ b/src/components/layouts/nightingale.js
@@ -7,7 +7,6 @@ import PureBaseLayout from "./PureBaseLayout";
 
 class NightingaleLayout extends PureBaseLayout {
   render() {
-    console.log(this.props.leftCoordinatesProps);
     const {
       leftCoordinatesProps,
       rightCoordinatesProps,

--- a/src/components/layouts/nightingale.js
+++ b/src/components/layouts/nightingale.js
@@ -1,25 +1,33 @@
 import React from "react";
+import { isEmpty } from "lodash-es";
 
-import {
-  // PositionBar,
-  Labels,
-  SequenceViewer,
-} from "../index";
+import { Labels, SequenceViewer, Coordinates } from "../index";
 
 import PureBaseLayout from "./PureBaseLayout";
 
 class NightingaleLayout extends PureBaseLayout {
   render() {
+    console.log(this.props.leftCoordinatesProps);
+    const {
+      leftCoordinatesProps,
+      rightCoordinatesProps,
+      labelsProps,
+    } = this.props;
+
     return (
       <div
         style={{
           display: "flex",
         }}
       >
-        {this.props.labelsProps && this.props.labelsProps.labelStyle && (
-          <Labels {...this.props.labelsProps} />
+        {!isEmpty(labelsProps) && <Labels {...labelsProps} />}
+        {!isEmpty(leftCoordinatesProps) && (
+          <Coordinates {...leftCoordinatesProps} />
         )}
         <SequenceViewer {...this.props.sequenceViewerProps} />
+        {!isEmpty(rightCoordinatesProps) && (
+          <Coordinates {...rightCoordinatesProps} />
+        )}
       </div>
     );
   }

--- a/src/components/yBars/Coordinates.js
+++ b/src/components/yBars/Coordinates.js
@@ -42,10 +42,10 @@ export class Coordinates extends PureComponent {
       width,
       tileHeight,
       tileWidth,
-      style: containerStyle,
       position,
       coordinateComponent,
       sequences,
+      coordinateStyle,
     } = this.props;
     const style = {
       height,
@@ -53,32 +53,38 @@ export class Coordinates extends PureComponent {
       position: "relative",
       whiteSpace: "nowrap",
     };
+
     // These assignments to props are neccessary so that withPositionStore will sync up scrolling
     this.props.position.lastCurrentViewSequence = position.currentViewSequence;
     this.props.position.lastStartYTile = 0;
+
     // Start and end coordinates of the current scrolled view
     // Calculating this rather than using currentViewSequencePosition as
     // we want to the start/end to increment by one when the scroll is past
     // half a tileWidth (which Math.round gives us)
-    const start = Math.round(position.xPos / tileWidth);
-    const end = start + Math.round(width / tileWidth) - 1;
+    // Use 1-based indexing as this how much sequences are indexed
+    const start = Math.round(position.xPos / tileWidth) + 1;
+    const end = start + Math.round(width / tileWidth) - 2;
+
+    // Use this to memo so off-view coordinates aren't re-rendered
     const nSequencesInView = Math.ceil(height / tileHeight);
     const lastSequenceInView = position.currentViewSequence + nSequencesInView;
     const inView = (index) =>
       index >= position.currentViewSequence && index <= lastSequenceInView;
+
     return (
-      <div style={containerStyle}>
+      <div>
         <div style={style} ref={this.el}>
           {sequences.map((sequence, index) => (
             <Coordinate
               key={index}
-              index={index}
-              start={start + sequence.start}
-              end={end + sequence.start}
+              start={start}
+              end={end}
               tileHeight={tileHeight}
-              height={height}
               coordinateComponent={coordinateComponent}
+              style={coordinateStyle}
               inView={inView(index)}
+              sequence={sequence}
             />
           ))}
         </div>
@@ -87,36 +93,59 @@ export class Coordinates extends PureComponent {
   }
 }
 
-// Coordinates.defaultProps = {
-//   labelStyle: {},
-// };
+Coordinates.propTypes = {
+  /**
+   * Width of the sequence viewer (in pixels), e.g. `500`.
+   */
+  width: PropTypes.number.isRequired,
 
-// Coordinates.propTypes = {
-//   /**
-//    * Font of the sequence labels, e.g. `20px Arial`
-//    */
-//   font: PropTypes.string,
+  /**
+   * Height of the sequence viewer (in pixels), e.g. `500`.
+   */
+  height: PropTypes.number.isRequired,
 
-//   /**
-//    * Component to create labels from.
-//    */
-//   labelComponent: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
+  /**
+   * Width of the main tiles (in pixels), e.g. `20`
+   */
+  tileWidth: PropTypes.number.isRequired,
 
-//   /**
-//    * Inline styles to apply to the Label component
-//    */
-//   style: PropTypes.object,
+  /**
+   * Height of the main tiles (in pixels), e.g. `20`
+   */
+  tileHeight: PropTypes.number.isRequired,
 
-//   /**
-//    * Inline styles to apply to each label.
-//    */
-//   labelStyle: PropTypes.object,
+  position: PropTypes.shape({
+    currentViewSequence: PropTypes.number.isRequired,
+    currentViewSequencePosition: PropTypes.number.isRequired,
+    lastCurrentViewSequence: PropTypes.number,
+    lastStartYTile: PropTypes.number,
+    xPos: PropTypes.number.isRequired,
+    xPosOffset: PropTypes.number.isRequired,
+    yPos: PropTypes.number.isRequired,
+    yPosOffset: PropTypes.number.isRequired,
+  }).isRequired,
 
-//   /**
-//    * Attributes to apply to each label.
-//    */
-//   labelAttributes: PropTypes.object,
-// };
+  /**
+   * Component to create labels from.
+   */
+  coordinateComponent: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
+
+  /**
+   * Inline styles to apply to each label.
+   */
+  coordinateStyle: PropTypes.object,
+
+  /**
+   * Attributes to apply to each label.
+   */
+  coordinateAttributes: PropTypes.object,
+};
+
+Coordinates.defaultProps = {
+  coordinateComponent: undefined,
+  coordinateStyle: {},
+  coordinateAttributes: {},
+};
 
 const mapStateToProps = (state) => {
   return {
@@ -125,7 +154,6 @@ const mapStateToProps = (state) => {
     tileHeight: state.props.tileHeight,
     tileWidth: state.props.tileWidth,
     sequences: state.sequences.raw,
-    nrYTiles: state.sequenceStats.nrYTiles,
   };
 };
 

--- a/src/components/yBars/Coordinates.js
+++ b/src/components/yBars/Coordinates.js
@@ -5,14 +5,20 @@ import msaConnect from "../../store/connect";
 import withPositionStore from "../../store/withPositionStore";
 
 const Coordinate = memo(
-  ({ coordinateComponent, ...otherProps }) => {
+  ({
+    coordinateComponent,
+    coordinateAttributes = {},
+    coordinateStyle = {},
+    ...otherProps
+  }) => {
     if (coordinateComponent) {
       const CoordinateComponent = coordinateComponent;
       return <CoordinateComponent {...otherProps} />;
     } else {
       const { start, end, tileHeight } = otherProps;
+      const attributes = { ...otherProps, ...coordinateAttributes };
       return (
-        <div style={{ height: tileHeight }}>
+        <div style={{ height: tileHeight, ...coordinateStyle }} {...attributes}>
           {start}-{end}
         </div>
       );
@@ -44,8 +50,9 @@ export class Coordinates extends PureComponent {
       tileWidth,
       position,
       coordinateComponent,
-      sequences,
+      coordinateAttributes,
       coordinateStyle,
+      sequences,
     } = this.props;
     const style = {
       height,
@@ -82,7 +89,8 @@ export class Coordinates extends PureComponent {
               end={end}
               tileHeight={tileHeight}
               coordinateComponent={coordinateComponent}
-              style={coordinateStyle}
+              coordinateStyle={coordinateStyle}
+              coordinateAttributes={coordinateAttributes}
               inView={inView(index)}
               sequence={sequence}
             />

--- a/src/components/yBars/Coordinates.js
+++ b/src/components/yBars/Coordinates.js
@@ -1,0 +1,129 @@
+import React, { PureComponent } from "react";
+import PropTypes from "prop-types";
+
+import msaConnect from "../../store/connect";
+import withPositionStore from "../../store/withPositionStore";
+
+const Coordinate = ({
+  coordinateComponent,
+  start,
+  end,
+  tileHeight,
+  style = {},
+  ...otherProps
+}) => {
+  style.height = tileHeight;
+  if (coordinateComponent) {
+    const CoordinateComponent = coordinateComponent;
+    return <CoordinateComponent style={style} {...otherProps} />;
+  } else {
+    return (
+      <div style={style}>
+        {start}-{end}
+      </div>
+    );
+  }
+};
+
+/**
+ * Displays the coordinates of the current scrolled position.
+ */
+export class Coordinates extends PureComponent {
+  constructor(props) {
+    super(props);
+    this.el = React.createRef();
+  }
+
+  shouldRerender() {
+    // Need this so that withPositionStore will provide new position information.
+    // See withPositionStore docstring for further information.
+    return true;
+  }
+
+  render() {
+    const {
+      height,
+      width,
+      tileHeight,
+      tileWidth,
+      style: containerStyle,
+      position,
+      coordinateComponent,
+    } = this.props;
+    const style = {
+      height,
+      overflow: "hidden",
+      position: "relative",
+      whiteSpace: "nowrap",
+    };
+    // These assignments to props are neccessary so that withPositionStore will sync up scrolling
+    this.props.position.lastCurrentViewSequence = position.currentViewSequence;
+    this.props.position.lastStartYTile = 0;
+    // Start and end coordinates of the current scrolled view
+    // Calculating this rather than using currentViewSequencePosition as
+    // we want to the start/end to increment by one when the scroll is past
+    // half a tileWidth (which Math.round gives us)
+    const start = Math.round(this.props.position.xPos / tileWidth) + 1;
+    const end = start + Math.round(width / tileWidth) - 1;
+    return (
+      <div style={containerStyle}>
+        <div style={style} ref={this.el}>
+          {this.props.sequences.map((_, index) => (
+            <Coordinate
+              key={index}
+              start={start}
+              end={end}
+              tileHeight={tileHeight}
+            />
+          ))}
+        </div>
+      </div>
+    );
+  }
+}
+
+// Coordinates.defaultProps = {
+//   labelStyle: {},
+// };
+
+// Coordinates.propTypes = {
+//   /**
+//    * Font of the sequence labels, e.g. `20px Arial`
+//    */
+//   font: PropTypes.string,
+
+//   /**
+//    * Component to create labels from.
+//    */
+//   labelComponent: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
+
+//   /**
+//    * Inline styles to apply to the Label component
+//    */
+//   style: PropTypes.object,
+
+//   /**
+//    * Inline styles to apply to each label.
+//    */
+//   labelStyle: PropTypes.object,
+
+//   /**
+//    * Attributes to apply to each label.
+//    */
+//   labelAttributes: PropTypes.object,
+// };
+
+const mapStateToProps = (state) => {
+  return {
+    width: state.props.width,
+    height: state.props.height,
+    tileHeight: state.props.tileHeight,
+    tileWidth: state.props.tileWidth,
+    sequences: state.sequences.raw,
+    nrYTiles: state.sequenceStats.nrYTiles,
+  };
+};
+
+export default msaConnect(mapStateToProps)(
+  withPositionStore(Coordinates, { withX: true, withY: true })
+);

--- a/src/components/yBars/Coordinates.js
+++ b/src/components/yBars/Coordinates.js
@@ -4,21 +4,14 @@ import PropTypes from "prop-types";
 import msaConnect from "../../store/connect";
 import withPositionStore from "../../store/withPositionStore";
 
-const Coordinate = ({
-  coordinateComponent,
-  start,
-  end,
-  tileHeight,
-  style = {},
-  ...otherProps
-}) => {
-  style.height = tileHeight;
+const Coordinate = ({ coordinateComponent, ...otherProps }) => {
   if (coordinateComponent) {
     const CoordinateComponent = coordinateComponent;
-    return <CoordinateComponent style={style} {...otherProps} />;
+    return <CoordinateComponent {...otherProps} />;
   } else {
+    const { start, end, tileHeight } = otherProps;
     return (
-      <div style={style}>
+      <div style={{ height: tileHeight }}>
         {start}-{end}
       </div>
     );
@@ -63,17 +56,19 @@ export class Coordinates extends PureComponent {
     // Calculating this rather than using currentViewSequencePosition as
     // we want to the start/end to increment by one when the scroll is past
     // half a tileWidth (which Math.round gives us)
-    const start = Math.round(this.props.position.xPos / tileWidth) + 1;
+    const start = Math.round(this.props.position.xPos / tileWidth);
     const end = start + Math.round(width / tileWidth) - 1;
     return (
       <div style={containerStyle}>
         <div style={style} ref={this.el}>
-          {this.props.sequences.map((_, index) => (
+          {this.props.sequences.map((sequence, index) => (
             <Coordinate
               key={index}
-              start={start}
-              end={end}
+              index={index}
+              start={start + sequence.start}
+              end={end + sequence.start}
               tileHeight={tileHeight}
+              coordinateComponent={coordinateComponent}
             />
           ))}
         </div>

--- a/src/stories/events.js
+++ b/src/stories/events.js
@@ -28,14 +28,14 @@ const sequences = [
 
 const features = [
   {
-    residues: { from: 1, to: 20 },
-    sequences: { from: 0, to: 0 },
+    residues: { from: 2, to: 15 },
+    sequences: { from: 0, to: 1 },
     id: "id-1",
     borderColor: "blue",
     fillColor: "black",
   },
   {
-    residues: { from: 3, to: 10 },
+    residues: { from: 25, to: 50 },
     sequences: { from: 2, to: 2 },
     id: "id-2",
     borderColor: "blue",

--- a/src/stories/layouts.js
+++ b/src/stories/layouts.js
@@ -18,10 +18,10 @@ import {
   SequenceViewer,
 } from "../lib";
 
-const sequences = [
+let sequences = [
   {
     name: "seq.1",
-    sequence: "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+    sequence: "MEEPQSDPS----PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
     start: 1,
   },
   {
@@ -56,31 +56,19 @@ const sequences = [
   },
 ];
 
-const Coordinate = ({ tileHeight, style = {}, children }) => (
-  <div style={{ height: tileHeight, ...style }}>{children}</div>
-);
-
-const LeftCoordinate = ({ start, style = {}, ...otherProps }) => (
-  <Coordinate
-    style={{
-      width: "3rem",
-      textAlign: "right",
-      paddingRight: "0.25rem",
-      ...style,
-    }}
-    {...otherProps}
-  >
-    {start}
-  </Coordinate>
-);
-
-const RightCoordinate = ({ end, style = {}, ...otherProps }) => {
-  return (
-    <Coordinate style={{ paddingLeft: "0.25rem" }} {...otherProps}>
-      {end}
-    </Coordinate>
-  );
+const leftCoordinateStyle = {
+  textAlign: "right",
+  paddingRight: "0.25rem",
 };
+
+const rightCoordinateStyle = {
+  paddingLeft: "0.25rem",
+};
+const Coordinate = ({ tileHeight, style, sequence, children: coord }) => (
+  <div style={{ height: tileHeight, width: "3rem", ...style }}>
+    {sequence.start + coord}
+  </div>
+);
 
 storiesOf("Layouting", module)
   .add("Inverse", function () {
@@ -162,11 +150,28 @@ storiesOf("Layouting", module)
       </MSAViewer>
     );
   })
-  .add("Nightingale", () => (
+  .add("Nightingale with left/right coords", () => (
     <MSAViewer
       sequences={sequences}
       layout="nightingale"
-      leftCoordinateComponent={LeftCoordinate}
-      rightCoordinateComponent={RightCoordinate}
+      leftCoordinateComponent={({ start, tileHeight, sequence }) => (
+        <Coordinate
+          tileHeight={tileHeight}
+          sequence={sequence}
+          style={leftCoordinateStyle}
+        >
+          {start}
+        </Coordinate>
+      )}
+      rightCoordinateComponent={({ end, tileHeight, sequence }) => (
+        <Coordinate
+          tileHeight={tileHeight}
+          sequence={sequence}
+          style={rightCoordinateStyle}
+        >
+          {end}
+        </Coordinate>
+      )}
+      height={200}
     />
   ));

--- a/src/stories/layouts.js
+++ b/src/stories/layouts.js
@@ -11,7 +11,6 @@ import { storiesOf } from "@storybook/react";
 import { MSAViewer } from "../lib";
 
 import {
-  createMSAStore,
   Labels,
   OverviewBar,
   PositionBar,
@@ -23,32 +22,65 @@ const sequences = [
   {
     name: "seq.1",
     sequence: "MEEPQSDPSIEP-PLSQETFSDLWKLLPENNVLSPLPS-QA-VDDLMLSPDDLAQWLTED",
+    start: 1,
   },
   {
     name: "seq.2",
     sequence: "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+    start: 40,
   },
   {
     name: "seq.3",
     sequence: "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+    start: 23,
   },
   {
     name: "seq.4",
     sequence: "MEEPQSDLSIEL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+    start: 102,
   },
   {
     name: "seq.5",
     sequence: "MEEPQSD--IEL-PLSEETFSDLWWPLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+    start: 998,
   },
   {
     name: "seq.6",
     sequence: "MEEPQEDLSSSL-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE-LFLSENVAGWLEDP",
+    start: 61,
   },
   {
     name: "seq.7",
     sequence: "MEEPQ---SISE-PLSQETFSDLWKLLPPNNVLSTLPS-SDSIEE---LSENVAGWLEDP",
+    start: 10,
   },
 ];
+
+const Coordinate = ({ tileHeight, style = {}, children }) => (
+  <div style={{ height: tileHeight, ...style }}>{children}</div>
+);
+
+const LeftCoordinate = ({ start, style = {}, ...otherProps }) => (
+  <Coordinate
+    style={{
+      width: "3rem",
+      textAlign: "right",
+      paddingRight: "0.25rem",
+      ...style,
+    }}
+    {...otherProps}
+  >
+    {start}
+  </Coordinate>
+);
+
+const RightCoordinate = ({ end, style = {}, ...otherProps }) => {
+  return (
+    <Coordinate style={{ paddingLeft: "0.25rem" }} {...otherProps}>
+      {end}
+    </Coordinate>
+  );
+};
 
 storiesOf("Layouting", module)
   .add("Inverse", function () {
@@ -129,4 +161,12 @@ storiesOf("Layouting", module)
         <SequenceOverview />
       </MSAViewer>
     );
-  });
+  })
+  .add("Nightingale", () => (
+    <MSAViewer
+      sequences={sequences}
+      layout="nightingale"
+      leftCoordinateComponent={LeftCoordinate}
+      rightCoordinateComponent={RightCoordinate}
+    />
+  ));

--- a/src/stories/layouts.js
+++ b/src/stories/layouts.js
@@ -150,7 +150,10 @@ storiesOf("Layouting", module)
       </MSAViewer>
     );
   })
-  .add("Nightingale with left/right coords", () => (
+  .add("Nightingale", () => (
+    <MSAViewer sequences={sequences} layout="nightingale" height={200} />
+  ))
+  .add("Nightingale with L/R coordinates", () => (
     <MSAViewer
       sequences={sequences}
       layout="nightingale"


### PR DESCRIPTION
- Create left/right coordinates on each side sequence in nightingale layout
- Performance _should_ still be good as off-view coordinates aren't rendered: above the view is a spacer with the correct height to maintain alignment; below the view the coordinates aren't rendered.
- Pass sequences to coordinate component in case consumer wants to use it (eg offset start/end, count number of gaps)
- Create nightingale layout story to showcase coordinates
- Add more proptypes to try to suppress console warnings about x not being a valid DOM attribute.